### PR TITLE
docs: default Laravel namespace path

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ Agents are registered with the `SparkleServer` facade in a service provider. Her
 ```php
 <?php
 
-namespace Workbench\App\Providers;
+namespace App\Providers;
 
 use EchoLabs\Sparkle\Facades\SparkleServer;
 use Illuminate\Support\ServiceProvider;
 use Workbench\App\Agents\MultiToolAgent;
 
-class WorkbenchServiceProvider extends ServiceProvider
+class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {


### PR DESCRIPTION
Hey TJ,

Great work on the package!
I'm building AI apps with Laravel, and I can already see how useful this will be.

This is my first pull request, which suggests an update to the README.
I recommend using the default namespace in the examples to reduce unnecessary complexity.

Thanks again for all your effort—really excited to see where this goes!